### PR TITLE
changing of encoding handling

### DIFF
--- a/textrank.py
+++ b/textrank.py
@@ -161,19 +161,19 @@ def parse_graf (doc_id, graf_text, base_idx):
         pos_family = pos_tag[1].lower()[0]
         raw_idx += 1
 
-      word = word._replace(raw = str(parsed_raw))
+      word = word._replace(raw = str(parsed_raw.encode('utf-8')))
 
       if pos_family in POS_LEMMA:
-        word = word._replace(root = str(parsed_raw.singularize().lemmatize(pos_family)).lower())
+        word = word._replace(root = str(parsed_raw.singularize().lemmatize(pos_family).encode('utf-8')).lower())
       elif pos_family != '.':
-        word = word._replace(root = str(parsed_raw).lower())
+        word = word._replace(root = str(parsed_raw.encode('utf-8')).lower())
       else:
-        word = word._replace(root = str(parsed_raw))
+        word = word._replace(root = str(parsed_raw.encode('utf-8')))
 
       if pos_family in POS_KEEPS:
         word = word._replace(word_id = get_word_id(word.root), keep = 1)
 
-      digest.update(word.root.encode("utf-8"))
+      digest.update(word.root)
 
       # schema: word_id, raw, root, pos, keep, idx
       if DEBUG:


### PR DESCRIPTION
For example try: "A series of novel xanthine-based tricyclic heterocycles in 1H-imidazo[4,5-c]quinolin-4(5H)-ones was designed, synthesized, and tested as potential active bronchodilators. Inhibition of the Schulz-Dale (SD) reaction-induced contraction in trachea and inhibition of antigen inhalation-induced bronchospasm in passively sensitized guinea pigs served as primary in vitro and in vivo assays, respectively. Simultaneous measurement of acute lethal toxicity (minimum lethal dose; MLD, po) in mice allowed determination of a safety margin. The bronchodilatory activity of these heterocycles was considerably varied with the nature of substituents at the 5-position. The most active substituents at the 2- and 5-positions and on the aromatic ring were found to be hydrogen, n-butyl, and hydrogen, respectively. There was a bulk tolerance for lipophilic substituents at the 1-position. 5-Butyl-substituted compounds appeared to be less toxic than theophylline on the basis of MLD data. Thus 5-butyl-1-methyl-1H-imidazo[4,5-c]quinolin-4(5H)-one (10) (IC50 value of the SD assay = 0.25 microM, MLD > 300 mg/kg) was selected for further studies. Compound 10 (KF15570) reduced bronchoconstriction produced by antigen (Konzett-Rössler preparation in anesthetized guinea pigs, ED50 = 0.42 mg/kg, iv) more effectively than aminophylline (ethylenediamine salt of theophylline, ED50 = 7.8 mg/kg, iv) but had fewer side effects on the heart and CNS than theophylline. Compound 10 and its derivatives showed weak adenosine antagonism and phosphodiesterase (PDE) inhibition which could not account for their potent bronchodilation. Although their precise mechanism of action remains unclear, this series of novel tricyclic heterocycles represents a new class of bronchodilator. "