### PR TITLE
Remove textblob-aptagger package dependency, which is deprecated.

### DIFF
--- a/pytextrank/pytextrank.py
+++ b/pytextrank/pytextrank.py
@@ -5,7 +5,7 @@ from collections import namedtuple
 from datasketch import MinHash
 from graphviz import Digraph
 from textblob import TextBlob
-from textblob_aptagger import PerceptronTagger
+from nltk.tag.perceptron import PerceptronTagger
 import hashlib
 import json
 import math

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 textblob==0.11.1
-textblob-aptagger==0.2.0
 
 spacy==1.3.0
 


### PR DESCRIPTION
As of `textblob` 0.11.0, which `pytextrank` uses, the `textblob-aptagger` library is no [longer needed](https://github.com/sloria/textblob-aptagger#textblob-aptagger). Per the package maintainer:

> As of TextBlob 0.11.0, TextBlob uses NLTK's averaged perceptron tagger by default. This package is no longer necessary.

This PR updates `pytextrank` with `from nltk.tag.perceptron import PerceptronTagger` and removes `textblob-aptagger` from the requirements.txt file